### PR TITLE
adding dynamic_content and simulate_packet modules

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,13 +21,13 @@ cp_gaia_virtual_gateway – manages virtual-gateway objects on Check Point machi
 cp_gaia_virtual_gateway_facts – get virtual-gateway objects facts on Check Point machine over Web Services API.
 cp_gaia_virtual_vsnext_state_facts – get the VSNext state on Check Point machine over Web Services API.
 
-v5.1.0
+v6.0.0
 ======
 
 Release Summary
 ---------------
 
-this release 5.1.0 of ``check_point.gaia``, released on 2023-11-1.
+this release 6.0.0 of ``check_point.gaia``, released on 2023-11-1.
 
 New Modules
 -----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,23 @@ cp_gaia_virtual_gateway – manages virtual-gateway objects on Check Point machi
 cp_gaia_virtual_gateway_facts – get virtual-gateway objects facts on Check Point machine over Web Services API.
 cp_gaia_virtual_vsnext_state_facts – get the VSNext state on Check Point machine over Web Services API.
 
+v5.1.0
+======
+
+Release Summary
+---------------
+
+this release 5.1.0 of ``check_point.gaia``, released on 2023-11-1.
+
+New Modules
+-----------
+
+- check_point.gaia.cp_gaia_dynamic_content – install policy on a dynamic layer Check Point machine over Web Services API.
+- check_point.gaia.cp_gaia_dynamic_content_layer_facts – get the details of the installed policy on a given dynamic layer on a Check Point machine over Web Services API.
+- check_point.gaia.cp_gaia_dynamic_content_layers_facts – get the details of all dynamic layers on a Check Point machine over Web Services API.
+- check_point.gaia.cp_gaia_simulate_packet – simulate packet rulebase execution on a Check Point machine over Web Services API.
+
+
 v5.0.1
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,24 @@ Check_Point.gaia Release Notes
 
 .. contents:: Topics
     
+
+v7.0.0
+======
+
+Release Summary
+---------------
+
+this release 7.0.0 of ``check_point.gaia``, released on 2025-1-1.
+
+New Modules
+-----------
+
+- check_point.gaia.cp_gaia_dynamic_content – install policy on a dynamic layer Check Point machine over Web Services API.
+- check_point.gaia.cp_gaia_dynamic_content_layer_facts – get the details of the installed policy on a given dynamic layer on a Check Point machine over Web Services API.
+- check_point.gaia.cp_gaia_dynamic_content_layers_facts – get the details of all dynamic layers on a Check Point machine over Web Services API.
+- check_point.gaia.cp_gaia_simulate_packet – simulate packet rulebase execution on a Check Point machine over Web Services API.
+
+
 v6.0.0
 ======
 
@@ -20,22 +38,6 @@ cp_gaia_virtual_switch_facts – get virtual-switch objects facts on Check Point
 cp_gaia_virtual_gateway – manages virtual-gateway objects on Check Point machine over Web Services API.
 cp_gaia_virtual_gateway_facts – get virtual-gateway objects facts on Check Point machine over Web Services API.
 cp_gaia_virtual_vsnext_state_facts – get the VSNext state on Check Point machine over Web Services API.
-
-v6.0.0
-======
-
-Release Summary
----------------
-
-this release 6.0.0 of ``check_point.gaia``, released on 2023-11-1.
-
-New Modules
------------
-
-- check_point.gaia.cp_gaia_dynamic_content – install policy on a dynamic layer Check Point machine over Web Services API.
-- check_point.gaia.cp_gaia_dynamic_content_layer_facts – get the details of the installed policy on a given dynamic layer on a Check Point machine over Web Services API.
-- check_point.gaia.cp_gaia_dynamic_content_layers_facts – get the details of all dynamic layers on a Check Point machine over Web Services API.
-- check_point.gaia.cp_gaia_simulate_packet – simulate packet rulebase execution on a Check Point machine over Web Services API.
 
 
 v5.0.1

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Modules
 * `cp_gaia_virtual_gateway` – manages virtual-gateway objects on Check Point machine over Web Services API.
 * `cp_gaia_virtual_gateway_facts` – get virtual-gateway objects facts on Check Point machine over Web Services API.
 * `cp_gaia_virtual_vsnext_state_facts` – get the VSNext state on Check Point machine over Web Services API.
+* `cp_gaia_dynamic_content` – install policy on a dynamic layer Check Point machine over Web Services API.
+* `cp_gaia_dynamic_content_layer_facts` – get the details of the installed policy on a given dynamic layer on a Check Point machine over Web Services API.
+* `cp_gaia_dynamic_content_layers_facts` – get the details of all dynamic layers on a Check Point machine over Web Services API.
+* `cp_gaia_simulate_packet` – simulate packet rulebase execution on a Check Point machine over Web Services API.
 
 ### Code of Conduct
 This collection follows the Ansible project's

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -41,6 +41,10 @@ checkpoint_argument_spec_for_async = dict(
     wait_for_task=dict(type='bool', default=True)
 )
 
+checkpoint_argument_spec_for_async_false = dict(
+    wait_for_task=dict(type='bool', default=False)
+)
+
 checkpoint_argument_spec_for_all = dict(
     version=dict(type='str'),
     virtual_system_id=dict(type="int", required=False)
@@ -72,8 +76,11 @@ def idempotency_check(old_val, new_val):
 
 # if user insert a specific version, we add it to the url
 def get_version(module):
-    res = ('v' + module.params['version'] + '/') if module.params.get('version') else ''
-    del module.params['version']
+    if module.params.get('version'):
+        res = ('v' + module.params['version'] + '/')
+        del module.params['version']
+    else:
+        res = ''
     return res
 
 

--- a/plugins/modules/cp_gaia_dynamic_content.py
+++ b/plugins/modules/cp_gaia_dynamic_content.py
@@ -51,10 +51,10 @@ options:
     wait_for_task:
         description: Wait for task or return immediately.
         required: False
-        default: false
+        default: False
         type: bool
 short_description: installing policy
-version_added: '5.1.0'
+version_added: '6.0.0'
 notes:
 - its advisable to perform with wait_for_task set to false and refer to show_task command
 """

--- a/plugins/modules/cp_gaia_dynamic_content.py
+++ b/plugins/modules/cp_gaia_dynamic_content.py
@@ -1,0 +1,161 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+author: Ophir Khill (@chkp-ophirk)
+description:
+- Installing policy
+module: cp_gaia_dynamic_content
+options:
+    version:
+        description: GAIA api version for ex 1.8
+        required: False
+        type: str
+    policy_path:
+        description: path for the policy json
+        required: True
+        type: str
+    dry_run:
+        description: dry_run set to true will apply the change, wheres set to false it will only validate the changes
+        required: True
+        type: bool
+    tags:
+        description: list of tags for the operation
+        required: True
+        type: list
+        elements: str
+    comments:
+        description: comments for the operation
+        required: True
+        type: str
+    wait_for_task:
+        description: Wait for task or return immediately.
+        required: False
+        default: false
+        type: bool
+short_description: installing policy
+version_added: '5.1.0'
+notes:
+- its advisable to perform with wait_for_task set to false and refer to show_task command
+"""
+
+EXAMPLES = """
+- name: Initial setup
+  check_point.gaia.cp_gaia_dynamic_content:
+    policy_path: "/home/admin/policy.json"
+    dry_run: false
+    tags: ["JIRA-12345", "apply layer1"]
+    comments: "testing the api"
+    wait_for_task: true
+"""
+
+RETURN = """
+change_summary:
+  description: change-summary after installing the new policy.
+  returned: always.
+  type: dict
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import checkpoint_argument_spec_for_all
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import chkp_api_operation
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import checkpoint_argument_spec_for_async_false
+import json
+
+NO_CHANGES = \
+    {
+        "layers": [],
+        "objects": {
+            "create": [],
+            "delete": [],
+            "modify": []
+        }
+    }
+
+KEYS_TO_REMOVE = ['comments', 'tags', 'dry-run']
+
+
+# load json
+def load_json_file(file_path):
+    try:
+        with open(file_path, 'r') as file:
+            data = json.load(file)
+            # remove unnecessary arguments
+            for key in KEYS_TO_REMOVE:
+                data.pop(key, None)
+
+            return data, None
+    except Exception as e:
+        return None, str(e)
+
+
+# check if the policy has changed
+def has_changed(result):
+    changed = True
+    change_summary = {}
+
+    try:
+        change_summary = result['set_dynamic_content']['tasks'][0]['task-details'][0]['change-summary']
+    except KeyError:
+        # no change summary
+        return changed
+
+    if change_summary == NO_CHANGES:
+        changed = False
+
+    return changed
+
+
+def main():
+    # arguments for the module:
+    fields = {
+        'policy_path': dict(type='str', required=True),
+        'dry_run': dict(type='bool', required=True),
+        'comments': dict(type='str', required=True),
+        'tags': dict(type='list', elements='str', required=True)
+    }
+    fields.update(checkpoint_argument_spec_for_async_false)
+    fields.update(checkpoint_argument_spec_for_all)
+    module = AnsibleModule(argument_spec=fields, supports_check_mode=True)
+
+    file_path = module.params['policy_path']
+
+    # load policy
+    result, error = load_json_file(file_path)
+    if error:
+        module.exit_json(changed=False, json_data=result)
+
+    # add policy to request
+    del module.params['policy_path']
+    module.params.update(result)
+    # call api operation
+    api_call_object = "set-dynamic-content"
+    res = chkp_api_operation(module, api_call_object)
+    # fill in 'changed' field
+    res['changed'] = has_changed(res)
+
+    module.exit_json(**res)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/cp_gaia_dynamic_content.py
+++ b/plugins/modules/cp_gaia_dynamic_content.py
@@ -54,7 +54,7 @@ options:
         default: False
         type: bool
 short_description: installing policy
-version_added: '6.0.0'
+version_added: '7.0.0'
 notes:
 - its advisable to perform with wait_for_task set to false and refer to show_task command
 """

--- a/plugins/modules/cp_gaia_dynamic_content_layer_facts.py
+++ b/plugins/modules/cp_gaia_dynamic_content_layer_facts.py
@@ -41,7 +41,7 @@ options:
         default: True
         type: bool
 short_description: getting information of the chosen dynamic layer.
-version_added: '5.1.0'
+version_added: '6.0.0'
 
 """
 

--- a/plugins/modules/cp_gaia_dynamic_content_layer_facts.py
+++ b/plugins/modules/cp_gaia_dynamic_content_layer_facts.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+author: Ophir Khill (@chkp-ophirk)
+description:
+- getting information of a chosen dynamic layer.
+module: cp_gaia_dynamic_content_layer_facts
+options:
+    version:
+        description: Gaia API version for example 1.6.
+        required: False
+        type: str
+    name:
+        description: dynamic layer to show
+        required: true
+        type: str
+    wait_for_task:
+        description: Wait for task or return immediately.
+        required: False
+        default: True
+        type: bool
+short_description: getting information of the chosen dynamic layer.
+version_added: '5.1.0'
+
+"""
+
+EXAMPLES = """
+- name: show dynamic layer
+  check_point.gaia.cp_gaia_dynamic_content_layer_facts:
+    name: dynamic_layer
+"""
+
+RETURN = """
+layer_summary:
+  description: the details of the installed policy on the requested layer
+  returned: always.
+  type: dict
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import chkp_api_call, checkpoint_argument_spec_for_all
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import chkp_api_operation
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import checkpoint_argument_spec_for_async
+
+
+def main():
+    # arguments for the module:
+    fields = dict(
+        name=dict(type='str', required=True)
+    )
+    fields.update(checkpoint_argument_spec_for_async)
+    fields.update(checkpoint_argument_spec_for_all)
+    module = AnsibleModule(argument_spec=fields, supports_check_mode=True)
+    api_call_object = 'show-dynamic-layer'
+
+    res = chkp_api_operation(module, api_call_object)
+
+    # this action does not change system configuration
+    res['changed'] = False
+
+    module.exit_json(**res)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/cp_gaia_dynamic_content_layer_facts.py
+++ b/plugins/modules/cp_gaia_dynamic_content_layer_facts.py
@@ -41,7 +41,7 @@ options:
         default: True
         type: bool
 short_description: getting information of the chosen dynamic layer.
-version_added: '6.0.0'
+version_added: '7.0.0'
 
 """
 

--- a/plugins/modules/cp_gaia_dynamic_content_layers_facts.py
+++ b/plugins/modules/cp_gaia_dynamic_content_layers_facts.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+author: Ophir Khill (@chkp-ophirk)
+description:
+- get the names and metadata of all dynamic layers
+module: cp_gaia_dynamic_content_layers_facts
+options:
+    version:
+        description: Gaia API version for example 1.6.
+        required: False
+        type: str
+    wait_for_task:
+        description: Wait for task or return immediately.
+        required: False
+        default: True
+        type: bool
+short_description: get the names and meta-data of all dynamic layers.
+version_added: '5.1.0'
+
+"""
+
+EXAMPLES = """
+- name: show dynamic layers
+  check_point.gaia.cp_gaia_dynamic_content_layers_facts:
+"""
+
+RETURN = """
+hostname:
+  description: the names and metadata of all dynamic layers.
+  returned: always.
+  type: dict
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import chkp_api_call, checkpoint_argument_spec_for_all
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import chkp_api_operation
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import checkpoint_argument_spec_for_async
+
+
+def main():
+    # arguments for the module:
+    fields = dict()
+    fields.update(checkpoint_argument_spec_for_async)
+    fields.update(checkpoint_argument_spec_for_all)
+    module = AnsibleModule(argument_spec=fields, supports_check_mode=True)
+    api_call_object = 'show-dynamic-layers'
+
+    res = chkp_api_operation(module, api_call_object)
+
+    # this action does not change system configuration
+    res['changed'] = False
+
+    module.exit_json(**res)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/cp_gaia_dynamic_content_layers_facts.py
+++ b/plugins/modules/cp_gaia_dynamic_content_layers_facts.py
@@ -37,7 +37,7 @@ options:
         default: True
         type: bool
 short_description: get the names and meta-data of all dynamic layers.
-version_added: '5.1.0'
+version_added: '6.0.0'
 
 """
 

--- a/plugins/modules/cp_gaia_dynamic_content_layers_facts.py
+++ b/plugins/modules/cp_gaia_dynamic_content_layers_facts.py
@@ -37,7 +37,7 @@ options:
         default: True
         type: bool
 short_description: get the names and meta-data of all dynamic layers.
-version_added: '6.0.0'
+version_added: '7.0.0'
 
 """
 

--- a/plugins/modules/cp_gaia_simulate_packet.py
+++ b/plugins/modules/cp_gaia_simulate_packet.py
@@ -115,7 +115,7 @@ options:
         default: True
         required: False
 short_description: installing policy
-version_added: '5.1.0'
+version_added: '6.0.0'
 notes:
 - its advisable to perform with wait_for_task set to false and refer to show_task command
 """

--- a/plugins/modules/cp_gaia_simulate_packet.py
+++ b/plugins/modules/cp_gaia_simulate_packet.py
@@ -1,0 +1,201 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+author: Ophir Khill (@chkp-ophirk)
+description:
+- simulate packet execution on both Access and NAT rulebase.
+module: cp_gaia_simulate_packet
+options:
+    version:
+        description: GAIA api version for ex 1.8
+        required: False
+        type: str
+    ip_version:
+        description: ip version of the packet.
+        type: str
+        required: False
+        default: '4'
+        choices: ['4', '6']
+    source_ip:
+        description: source ip of the packet.
+        type: str
+        required: True
+    destination_ip:
+        description: destination ip of the packet.
+        required: True
+        type: str
+    ip_protocol:
+        description: destination ip of the packet.
+        required: True
+        type: str
+    protocol_options:
+        description: protocol specific options.
+        required: True
+        type: dict
+        suboptions:
+            UDP:
+                description: UDP specific options.
+                required: False
+                type: dict
+                suboptions:
+                    source_port:
+                        description: source port of the packet.
+                        required: False
+                        default: '12345'
+                        type: str
+                    destination_port:
+                        description: destination port of the packet.
+                        required: True
+                        type: str
+            TCP:
+                description: TCP specific options.
+                required: False
+                type: dict
+                suboptions:
+                    source_port:
+                        description: source port of the packet.
+                        required: False
+                        default: '12345'
+                        type: str
+                    destination_port:
+                        description: destination port of the packet.
+                        required: True
+                        type: str
+            icmp:
+                description: ICMP specific options.
+                required: False
+                type: dict
+                suboptions:
+                    type:
+                        description: source port of the packet.
+                        required: True
+                        type: str
+                    code:
+                        description: destination port of the packet.
+                        required: False
+                        default: '0'
+                        type: str
+    incoming_interface:
+        description: packet's incoming interface, set to 'localhost' for outbound packets.
+        type: str
+        required: True
+    application:
+        description: list of Applications/Categorys as defined in SmartConsole. You can specify one or more applications
+        type: list
+        required: False
+        elements: str
+    protocol:
+        description: Protocol to match for services that have 'Protocol Signature' enabled.
+        type: str
+        required: False
+    wait_for_task:
+        description: Wait for task or return immediately.
+        type: bool
+        default: True
+        required: False
+short_description: installing policy
+version_added: '5.1.0'
+notes:
+- its advisable to perform with wait_for_task set to false and refer to show_task command
+"""
+
+EXAMPLES = """
+        - name: simulate packet
+          check_point.gaia.cp_gaia_simulate_packet:
+                    ip_version: "4"
+                    source_ip: "1.2.3.4"
+                    destination_ip: "2.3.4.5"
+                    ip_protocol: "1"
+                    protocol_options: {icmp: {type: "8"}}
+                    incoming_interface: "eth0"
+                    application: "Facebook"
+                    protocol: "HTTP"
+"""
+
+RETURN = """
+packet rulebase execution result:
+  description: the NAT and Access rulebase execution result.
+  returned: always.
+  type: dict
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import checkpoint_argument_spec_for_all
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import chkp_api_operation
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import checkpoint_argument_spec_for_async
+
+
+def main():
+    # arguments for the module:
+    fields = dict(
+        ip_version=dict(type='str', choices=['4', '6'], default='4'),
+        source_ip=dict(type='str', required=True),
+        destination_ip=dict(type='str', required=True),
+        ip_protocol=dict(type='str', required=True),
+        protocol_options=dict(
+            type='dict',
+            required=True,
+            options=dict(
+                TCP=dict(
+                    type='dict',
+                    options=dict(
+                        source_port=dict(type='str', default='12345'),
+                        destination_port=dict(type='str', required=True)
+                    )
+                ),
+                UDP=dict(
+                    type='dict',
+                    options=dict(
+                        source_port=dict(type='str', default='12345'),
+                        destination_port=dict(type='str', required=True)
+                    )
+                ),
+                icmp=dict(
+                    type='dict',
+                    options=dict(
+                        type=dict(type='str', required=True),
+                        code=dict(type='str', default='0')
+                    )
+                ),
+            )
+        ),
+        incoming_interface=dict(type='str', required=True),
+        application=dict(type='list', elements='str', required=False),
+        protocol=dict(type='str', required=False)
+    )
+    fields.update(checkpoint_argument_spec_for_async)
+    fields.update(checkpoint_argument_spec_for_all)
+    module = AnsibleModule(argument_spec=fields, supports_check_mode=True)
+
+    api_call_object = "simulate-packet"
+    res = chkp_api_operation(module, api_call_object)
+
+    # this action does not change system configuration
+    res['changed'] = False
+
+    module.exit_json(**res)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/cp_gaia_simulate_packet.py
+++ b/plugins/modules/cp_gaia_simulate_packet.py
@@ -115,7 +115,7 @@ options:
         default: True
         required: False
 short_description: installing policy
-version_added: '6.0.0'
+version_added: '7.0.0'
 notes:
 - its advisable to perform with wait_for_task set to false and refer to show_task command
 """


### PR DESCRIPTION
added new modules : 

- check_point.gaia.cp_gaia_dynamic_content – install policy on a dynamic layer Check Point machine over Web Services API.
- check_point.gaia.cp_gaia_dynamic_content_layer_facts – get the details of the installed policy on a given dynamic layer on a Check Point machine over Web Services API.
- check_point.gaia.cp_gaia_dynamic_content_layers_facts – get the details of all dynamic layers on a Check Point machine over Web Services API.
- check_point.gaia.cp_gaia_simulate_packet – simulate packet rulebase execution on a Check Point machine over Web Services API.
