### PR TITLE
Add alias interface modules

### DIFF
--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -55,8 +55,12 @@ def idempotency_check(old_val, new_val):
     if isinstance(new_val, dict):
         for key in new_val:
             if key in old_val:
-                if idempotency_check(old_val[key], new_val[key]) is False:
-                    return False
+                if key == 'ipv4_mask_length' or key == 'ipv6_mask_length':  # mask-lengths incorrectly come in as 'str' type from show-... api
+                  if idempotency_check(int(old_val[key]), int(new_val[key])) is False:
+                      return False
+                else:
+                  if idempotency_check(old_val[key], new_val[key]) is False:
+                      return False
     elif isinstance(new_val, list):
         if len(new_val) != len(old_val):
             return False

--- a/plugins/modules/cp_gaia_alias_interface.py
+++ b/plugins/modules/cp_gaia_alias_interface.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+module: cp_gaia_alias_interface
+author: Ameer Asli (@chkp-ameera)
+description:
+- Modify alias interface.
+short_description: Modify alias interface.
+version_added: '3.0.0'
+notes:
+- Supports C(check_mode).
+options:
+  version:
+    description: Gaia API version for example 1.6.
+    required: False
+    type: str
+  state:
+    description: Ansible state which can be C(present) or C(absent).
+    required: False
+    type: str
+    default: present
+    choices: [present, absent]
+  name:
+    description: Interface name with format "<parent interface>:<id>", for example  eth0:1, eth0:2 .. etc.
+    required: true
+    type: str
+  ipv4_address:
+      description: Interface IPv4 address.
+      required: false
+      type: str
+  ipv4_mask_length:
+      description: Interface IPv4 address mask length.
+      required: false
+      type: int
+"""
+
+EXAMPLES = """
+- name: Set comment field of a alias interface
+  check_point.gaia.cp_gaia_alias_interface:
+    comments: "eth0:1 interface"
+    name: eth0:1
+
+"""
+
+RETURN = """
+alias_interface:
+  description: The updated interface details.
+  returned: always.
+  type: dict
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import chkp_api_call, checkpoint_argument_spec_for_all
+
+
+def main():
+    # arguments for the module:
+    fields = dict(
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        name=dict(required=True, type='str'),
+        ipv4_address=dict(type='str'),
+        ipv4_mask_length=dict(type='int')
+    )
+    fields.update(checkpoint_argument_spec_for_all)
+    module = AnsibleModule(argument_spec=fields, supports_check_mode=True)
+    api_call_object = 'alias-interface'
+    ignore = ['parent']
+    show_params = ['name']
+    add_params = {}
+    parent_and_id = module.params["name"].split(":")
+    if len(parent_and_id) == 2:
+        add_params = {"parent": parent_and_id[0] }
+
+    res = chkp_api_call(module, api_call_object, True, ignore=ignore, show_params=show_params, add_params=add_params)
+    module.exit_json(**res)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/cp_gaia_alias_interface_facts.py
+++ b/plugins/modules/cp_gaia_alias_interface_facts.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+module: cp_gaia_alias_interface_facts
+author: Duane Toler (@duanetoler)
+description:
+- Show alias interface.
+short_description: Show alias interface/s.
+version_added: '5.0.x'
+notes:
+- Supports C(check_mode).
+options:
+  version:
+    description: Gaia API version for example 1.6.
+    required: False
+    type: str
+  name:
+    description: Interface name to show. If not specified, all alias interfaces information is returned.
+    required: false
+    type: str
+
+"""
+
+EXAMPLES = """
+- name: Show alias interface
+  check_point.gaia.cp_gaia_alias_interface_facts:
+
+- name: Show alias interface by specifying it's name
+  check_point.gaia.cp_gaia_alias_interface_facts:
+    name: eth0:1
+
+"""
+
+RETURN = """
+ansible_facts:
+    description: The interface/s facts.
+    returned: always.
+    type: dict
+    contains:
+        objects:
+            description:
+              - List of interfaces.
+            returned: always
+            type: list
+            elements: dict
+            contains:
+                name:
+                    description:
+                      - Interface name.
+                    returned: always
+                    type: str
+                ipv4_address:
+                    description: Interface IPv4 address.
+                    returned: always
+                    type: str
+                ipv4_mask_length:
+                    description: Interface IPv4 address mask length.
+                    returned: always
+                    type: int
+                enabled:
+                    description: Interface State.
+                    returned: always
+                    type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import chkp_facts_api_call, checkpoint_argument_spec_for_all
+
+
+def main():
+    # arguments for the module:
+    fields = dict(
+        name=dict(required=False, type='str')
+    )
+    fields.update(checkpoint_argument_spec_for_all)
+    module = AnsibleModule(argument_spec=fields, supports_check_mode=True)
+    api_call_object = "alias-interface"
+
+    res = chkp_facts_api_call(module, api_call_object, True)
+    module.exit_json(ansible_facts=res["ansible_facts"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Update checkpoint.py idempotency_check to handle ipv4/ipv6 mask length key values as int.  This allows skipping non-existent set-alias-interface API correctly
Tested with R81.20 JHF 41, Gaia APi 1.7