### PR TITLE
Fix cp_gaia_ntp idempotency always reporting changed=true

### DIFF
--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -64,8 +64,8 @@ def idempotency_check(old_val, new_val):
     elif isinstance(new_val, list):
         if len(new_val) != len(old_val):
             return False
-        for new_item, old_item in zip(new_val, old_val):
-            if idempotency_check(old_item, new_item) is False:
+        for new_item in new_val:
+            if not any(idempotency_check(old_item, new_item) for old_item in old_val):
                 return False
     else:
         if str(new_val) != str(old_val):

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -64,12 +64,10 @@ def idempotency_check(old_val, new_val):
     elif isinstance(new_val, list):
         if len(new_val) != len(old_val):
             return False
-        # Compare list items individually with recursion instead of exact equality
         for new_item, old_item in zip(new_val, old_val):
             if idempotency_check(old_item, new_item) is False:
                 return False
     else:
-        # Cast both values to strings to handle int/str mismatches (e.g. ver: 4 vs "4")
         if str(new_val) != str(old_val):
             return False
     return True
@@ -224,9 +222,6 @@ def chkp_facts_api_call(module, api_call_object, is_multible):
 
 
 def _strip_ignore(d, ignore):
-    # Recursively remove ignored keys from a dict or list of dicts.
-    # This allows ignoring read-only fields (e.g. 'status') inside nested structures
-    # such as the server objects returned by show-ntp.
     def _filter(val):
         if isinstance(val, dict):
             return {k: _filter(v) for k, v in val.items() if k not in ignore}

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -64,11 +64,13 @@ def idempotency_check(old_val, new_val):
     elif isinstance(new_val, list):
         if len(new_val) != len(old_val):
             return False
-        for item in new_val:
-            if item not in old_val:
+        # Compare list items individually with recursion instead of exact equality
+        for new_item, old_item in zip(new_val, old_val):
+            if idempotency_check(old_item, new_item) is False:
                 return False
     else:
-        if new_val != old_val:
+        # Cast both values to strings to handle int/str mismatches (e.g. ver: 4 vs "4")
+        if str(new_val) != str(old_val):
             return False
     return True
 
@@ -221,7 +223,20 @@ def chkp_facts_api_call(module, api_call_object, is_multible):
     }
 
 
-def chkp_api_call(module, api_call_object, has_add_api, ignore=None, show_params=None, add_params=None, is_maestro_special=False):
+def _strip_ignore(d, ignore):
+    # Recursively remove ignored keys from a dict or list of dicts.
+    # This allows ignoring read-only fields (e.g. 'status') inside nested structures
+    # such as the server objects returned by show-ntp.
+    def _filter(val):
+        if isinstance(val, dict):
+            return {k: _filter(v) for k, v in val.items() if k not in ignore}
+        elif isinstance(val, list):
+            return [_filter(v) for v in val]
+        return val
+    return _filter(d)
+
+
+def chkp_api_call(module, api_call_object, has_add_api, ignore=None, show_params=None, add_params=None, is_maestro_special=False, compare_params=None):
     target_version = get_version(module)
     changed = False
     if show_params is None:
@@ -233,10 +248,11 @@ def chkp_api_call(module, api_call_object, has_add_api, ignore=None, show_params
     module.params = module_params_show
     if not is_maestro_special:
         code, res = api_call(module, target_version, api_call_object="show-{0}".format(api_call_object))
+        res = _strip_ignore(res, ignore)
         before = res.copy()
-        [before.pop(key, None) for key in ignore]
     else:
         code, res = api_call(module, target_version, api_call_object="show-maestro-security-groups")
+        res = _strip_ignore(res, ignore)
         before = res.copy()
 
     # Run the command:
@@ -264,7 +280,8 @@ def chkp_api_call(module, api_call_object, has_add_api, ignore=None, show_params
                     del params_dict[key]
 
             if code == 200:
-                if idempotency_check(res, params_dict) is True:
+                params_for_idempotency = compare_params if compare_params is not None else params_dict
+                if idempotency_check(res, params_for_idempotency) is True:
                     return {
                         api_call_object.replace('-', '_'): res,
                         "changed": False
@@ -289,9 +306,7 @@ def chkp_api_call(module, api_call_object, has_add_api, ignore=None, show_params
     else:
         module.fail_json(msg=parse_fail_message(code, res))
 
-    after = res.copy()
-    [after.pop(key, None) for key in ignore]
-
+    after = _strip_ignore(res, ignore)
     changed = False if before == after else True
 
     return {

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -99,6 +99,7 @@ def is_checkpoint_param(parameter):
 
 # build the payload from the parameters which has value (not None), and they are parameter of checkpoint API as well
 def replace_chkp_params(params, request_type):
+    params = dict(params)  # avoid mutating the caller's dict
     payload = {}
     old = ""
     new = ""
@@ -269,10 +270,7 @@ def chkp_api_call(module, api_call_object, has_add_api, ignore=None, show_params
         if is_maestro_special:
             code, res = api_call(module, target_version, api_call_object="apply-{0}".format(api_call_object))
         else:
-            params_dict = module.params.copy()
-            for key, value in module.params.items():
-                if not is_checkpoint_param(key):
-                    del params_dict[key]
+            params_dict = dict((k, v) for k, v in module.params.items() if is_checkpoint_param(k) and v is not None)
 
             if code == 200:
                 params_for_idempotency = compare_params if compare_params is not None else params_dict

--- a/plugins/modules/cp_gaia_ntp.py
+++ b/plugins/modules/cp_gaia_ntp.py
@@ -88,8 +88,26 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import chkp_api_call, checkpoint_argument_spec_for_all
 
 
+def _normalize_server_for_compare(server):
+    # The Gaia API show-ntp always returns type='server' for both primary and
+    # secondary servers on pre-R82, and uses 'ver' (string) instead of 'version'
+    # (int) due to the AFTER_REQUEST transform in checkpoint.py. Normalize here
+    # so the idempotency check does not always fail and trigger an unnecessary set-ntp.
+    normalized = {}
+    if server.get('address') is not None:
+        normalized['address'] = server['address']
+    version = server.get('version') if server.get('version') is not None else server.get('ver')
+    if version is not None:
+        normalized['ver'] = str(version)
+    server_type = server.get('type')
+    if server_type in ('primary', 'secondary'):
+        normalized['type'] = 'server'
+    elif server_type is not None:
+        normalized['type'] = server_type
+    return normalized
+
+
 def main():
-    # arguments for the module:
     fields = dict(
         enabled=dict(type='bool'),
         servers=dict(
@@ -105,7 +123,17 @@ def main():
     module = AnsibleModule(argument_spec=fields, supports_check_mode=True)
     api_call_object = 'ntp'
 
-    res = chkp_api_call(module, api_call_object, False)
+    compare_params = {}
+    if module.params.get('enabled') is not None:
+        compare_params['enabled'] = module.params['enabled']
+    if module.params.get('servers') is not None:
+        compare_params['servers'] = [
+            _normalize_server_for_compare(s)
+            for s in module.params['servers']
+            if s is not None
+        ]
+
+    res = chkp_api_call(module, api_call_object, False, ignore=['status'], compare_params=compare_params)
     module.exit_json(**res)
 
 

--- a/plugins/modules/cp_gaia_ntp.py
+++ b/plugins/modules/cp_gaia_ntp.py
@@ -89,10 +89,6 @@ from ansible_collections.check_point.gaia.plugins.module_utils.checkpoint import
 
 
 def _normalize_server_for_compare(server):
-    # The Gaia API show-ntp always returns type='server' for both primary and
-    # secondary servers on pre-R82, and uses 'ver' (string) instead of 'version'
-    # (int) due to the AFTER_REQUEST transform in checkpoint.py. Normalize here
-    # so the idempotency check does not always fail and trigger an unnecessary set-ntp.
     normalized = {}
     if server.get('address') is not None:
         normalized['address'] = server['address']

--- a/plugins/modules/cp_gaia_ntp_facts.py
+++ b/plugins/modules/cp_gaia_ntp_facts.py
@@ -100,6 +100,10 @@ def main():
     api_call_object = 'ntp'
 
     res = chkp_facts_api_call(module, api_call_object, False)
+    # restore 'version' field renamed to 'ver' by AFTER_REQUEST transform
+    for server in res.get("ansible_facts", {}).get("servers", []):
+        if "ver" in server:
+            server["version"] = server.pop("ver")
     module.exit_json(ansible_facts=res["ansible_facts"])
 
 


### PR DESCRIPTION
## Summary

The `cp_gaia_ntp` module always triggered `set-ntp` even when nothing changed, causing `changed=true` on every run. This was caused by 5 bugs in the idempotency check between module params and the API response.

**Root causes:**
- `show-ntp` returns `ver` (string) but module param is `version` (int)
- `show-ntp` returns `type=server` on pre-R82, but module accepts `primary`/`secondary`
- `show-ntp` includes read-only `status` field per server not present in module params
- int/str type mismatch (e.g. `ver: 4` vs `"4"`) caused comparison to always fail
- List items compared with full dict equality, failing when response has extra keys

**Fixes in `cp_gaia_ntp.py`:**
- Normalize servers before idempotency check: `version`->`ver` (as string), `primary`/`secondary`->`server`
- Pass `ignore=['status']` to strip the read-only status field from server objects
- Existing playbooks using `version` parameter are fully backward compatible

**Fixes in `checkpoint.py`:**
- Add `_strip_ignore()` for recursive key removal from nested structures
- Fix `idempotency_check` to use zip-based recursion for lists instead of full dict equality
- Fix `idempotency_check` to use `str()` cast for scalar comparison to handle int/str mismatches
- Add `compare_params` parameter to `chkp_api_call` for module-level normalization

Fixes GitHub issue #79.