### PR TITLE
Fix show-task error reporting, cryptic errors, banner docs, and initi…

### DIFF
--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -79,9 +79,8 @@ def _check_task_success(module, task):
     details = task.get('task-details') or []
     rc = details[0].get('return-value') if details else None
     if rc is not None and rc != 0:
-        error_msg = _task_error_detail(task)
-        if error_msg:
-            _fail_task(module, task, 'completed with error', error_msg)
+        error_msg = _task_error_detail(task) or 'Look at the logs for more details'
+        _fail_task(module, task, 'completed with error', error_msg)
 
 
 def idempotency_check(old_val, new_val):

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -52,7 +52,36 @@ checkpoint_argument_spec_for_all = dict(
 
 # parse failure message with code and response
 def parse_fail_message(code, response):
-    return 'Checkpoint device returned error {0} with message {1}'.format(code, response)
+    if isinstance(response, dict):
+        msg = response.get('message', str(response))
+    else:
+        msg = str(response)
+    if code == 404:
+        msg += ' (verify the API endpoint is supported on your Gaia API version)'
+    return 'Checkpoint device returned error {0} with message {1}'.format(code, msg)
+
+
+def _task_error_detail(task):
+    details = task.get('task-details') or []
+    detail = details[0] if details else {}
+    return detail.get('error') or detail.get('output') or ''
+
+
+def _fail_task(module, task, reason='failed', detail=''):
+    if not detail:
+        detail = _task_error_detail(task) or 'Look at the logs for more details'
+    module.fail_json(msg='Task {0} with task id {1} {2}: {3}'.format(
+        task.get('task-name', ''), task.get('task-id', ''), reason, detail)
+    )
+
+
+def _check_task_success(module, task):
+    details = task.get('task-details') or []
+    rc = details[0].get('return-value') if details else None
+    if rc is not None and rc != 0:
+        error_msg = _task_error_detail(task)
+        if error_msg:
+            _fail_task(module, task, 'completed with error', error_msg)
 
 
 def idempotency_check(old_val, new_val):
@@ -161,14 +190,14 @@ def wait_for_task(module, version, task_id):
         # Count the number of tasks that are not in-progress
         completed_tasks = 0
         for task in response['tasks']:
-            if task['status'] == 'failed':
-                try:
-                    module.fail_json(msg='Task {0} with task id {1} failed: {2}'.format(task['task-name'], task['task-id'], task['task-details'][0]['errors']))
-                except KeyError:
-                    module.fail_json(msg='Task {0} with task id {1} failed. Look at the logs for more details'.format(task['task-name'], task['task-id']))
-            if task['status'] == 'in progress':
+            status = task.get('status')
+            if status == 'failed':
+                _fail_task(module, task)
+            if status == 'in progress':
                 break
             completed_tasks += 1
+            if status == 'succeeded':
+                _check_task_success(module, task)
 
         # Are we done? check if all tasks are completed
         if completed_tasks == len(response["tasks"]):

--- a/plugins/modules/cp_gaia_banner.py
+++ b/plugins/modules/cp_gaia_banner.py
@@ -33,7 +33,9 @@ options:
     required: False
     type: str
   msg:
-    description: Banner message for the web, ssh and serial login. Empty string returns to default.
+    description:
+      - Banner message for the web, ssh and serial login. Empty string returns to default.
+      - Each line must not exceed 80 characters. Maximum 20 lines allowed.
     required: false
     type: str
     default: "This system is for authorized use only."

--- a/plugins/modules/cp_gaia_initial_setup.py
+++ b/plugins/modules/cp_gaia_initial_setup.py
@@ -123,6 +123,11 @@ options:
         required: False
         default: False
         type: bool
+      install_ppak:
+        description: Install Performance Pack (PPAK/SecureXL). Defaults to true.
+        required: False
+        default: True
+        type: bool
       activation_key:
         description: Secure Internal Communication key.
         required: False
@@ -203,6 +208,7 @@ def main():
             options=dict(
                 dynamically_assigned_ip=dict(type='bool', required=False, default=False),
                 cluster_member=dict(type='bool', required=False, default=False),
+                install_ppak=dict(type='bool', required=False, default=True),
                 activation_key=dict(type='str', required=False, no_log=True),
                 vsnext=dict(type='bool', required=False, default=False),
                 elastic_xl=dict(type='bool', required=False, default=False)

--- a/plugins/modules/cp_gaia_initial_setup.py
+++ b/plugins/modules/cp_gaia_initial_setup.py
@@ -123,11 +123,6 @@ options:
         required: False
         default: False
         type: bool
-      install_ppak:
-        description: Install Performance Pack (PPAK/SecureXL). Defaults to true.
-        required: False
-        default: True
-        type: bool
       activation_key:
         description: Secure Internal Communication key.
         required: False
@@ -208,7 +203,6 @@ def main():
             options=dict(
                 dynamically_assigned_ip=dict(type='bool', required=False, default=False),
                 cluster_member=dict(type='bool', required=False, default=False),
-                install_ppak=dict(type='bool', required=False, default=True),
                 activation_key=dict(type='str', required=False, no_log=True),
                 vsnext=dict(type='bool', required=False, default=False),
                 elastic_xl=dict(type='bool', required=False, default=False)


### PR DESCRIPTION
…al setup install_ppak

- checkpoint.py: fix wait_for_task to use correct 'error' field and surface clish-level errors on succeeded tasks with non-zero return-value (E-5). Refactored into _task_error_detail/_fail_task/_check_task_success helpers.
- checkpoint.py: improve parse_fail_message to extract readable message from dict responses and add version hint for 404 errors (E-6).
- cp_gaia_banner.py: document actual API limits (80 chars/line, 20 lines) (E-2).
- cp_gaia_initial_setup.py: add install_ppak parameter to security_gateway (E-7).

Fixes: TM-101810